### PR TITLE
fix track file opening

### DIFF
--- a/TrackEditor.cpp
+++ b/TrackEditor.cpp
@@ -758,12 +758,13 @@ void CTrackEditorApp::OnFileOpen()
   char fileName[256];
 
   strcpy(fileName, "*.dat");
-  CFileDialog* fdlg = new CFileDialog(TRUE, "txt", (LPCSTR)&fileName, OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, lpszTrackFileFilter);
+  CFileDialog* fdlg = new CFileDialog(TRUE, "dat", (LPCSTR)&fileName, OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, lpszTrackFileFilter);
 
   int result = fdlg->DoModal();
 
   if (result == IDOK) {
-    AfxGetApp()->OpenDocumentFile(fdlg->GetFileName());
+    CString selectedFilePath = fdlg->GetPathName();
+    AfxGetApp()->OpenDocumentFile(selectedFilePath);
   }
 }
 


### PR DESCRIPTION
Fixes "file not found" message when trying to open a track file.

Example:
For some reason it assumes the file path is the program file path
![image](https://github.com/user-attachments/assets/63049574-69c0-43b0-a3eb-2a122aeb6de2)
