### PR TITLE
Add missing texture locations descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/.vs
+**/Release
+**/Debug

--- a/GPTrack.cpp
+++ b/GPTrack.cpp
@@ -755,6 +755,7 @@ void GPTrack::ReadTrackFile(CDocument *pDoc, const char *filename)
 
   ParseTrack(pDoc);
   ReadObjNames();
+  setFileName(filename);
   // ReadAnnotations();
   // if (showReadObjNames) ReadObjNames();
 }

--- a/TextureChooser.cpp
+++ b/TextureChooser.cpp
@@ -68,8 +68,8 @@ BOOL CTextureChooser::OnInitDialog()
 
   m_TextureCombo.AddString("Unk(0)");
   m_TextureCombo.AddString("Unk(1)");
-  m_TextureCombo.AddString("Unk(2)");
-  m_TextureCombo.AddString("Unk(3)");
+  m_TextureCombo.AddString("A Right Kerb Outside(2)");
+  m_TextureCombo.AddString("A Left  Kerb Outside(3)");
   m_TextureCombo.AddString("Right Fence(4)");
   m_TextureCombo.AddString("Left Fence(5)");
 
@@ -85,10 +85,15 @@ BOOL CTextureChooser::OnInitDialog()
   m_TextureCombo.AddString("Ribbon3(13)");
   m_TextureCombo.AddString("Ribbon4(14)");
   m_TextureCombo.AddString("Unk(15)");
-  m_TextureCombo.AddString("Unk(16)");
-  m_TextureCombo.AddString("Unk(17)");
+  m_TextureCombo.AddString("A Right Kerb Inside(16)");
+  m_TextureCombo.AddString("A Left Kerb Inside(17)");
   m_TextureCombo.AddString("Bank Right(19)");
   m_TextureCombo.AddString("Bank Left(18)");
+  m_TextureCombo.AddString("Pitlane On/Off Ramp(20)");
+  m_TextureCombo.AddString("B Right Kerb Outside(25)");
+  m_TextureCombo.AddString("B Left  Kerb Outside(26)");
+  m_TextureCombo.AddString("B Right Kerb Inside(27)");
+  m_TextureCombo.AddString("B Left Kerb Inside(28)");
 
   TRACE("SelectedLocation=%d", SelectedLocation);
   m_TextureCombo.SetCurSel(SelectedLocation);
@@ -128,7 +133,7 @@ BOOL CTextureChooser::OnInitDialog()
   SetDlgItemInt(IDC_EDIT6, SelectedTexture);
 
   return TRUE;// return TRUE unless you set the focus to a control
-    // EXCEPTION: OCX Property Pages should return FALSE
+              // EXCEPTION: OCX Property Pages should return FALSE
 }
 
 static void
@@ -181,6 +186,8 @@ static t_Texture TextureDesc[] = {
 
   { 0x21, "Road", "Unk", IDB_SIDE_TARMAC },
   { 0x22, "Grass", "Unk", IDB_SIDE_GRASS },
+
+  { 0x23, "Crowd", "crowd4.jam", IDB_CROWDICON },
 
   { 0x45, "Concrete Wall", "monaco22.jam", IDB_SIDE_TARMAC },
 
@@ -274,6 +281,12 @@ getTextureLocation(int id)
   static char buffer[256];
 
   switch (id) {
+  case 2:
+    wsprintf(buffer, "Type A Right Kerb Outside Part(%d)", id);
+    break;
+  case 3:
+    wsprintf(buffer, "Type A Left Kerb Outside Part(%d)", id);
+    break;
   case 4:
     wsprintf(buffer, "Right Fence(%d)", id);
     break;
@@ -301,13 +314,33 @@ getTextureLocation(int id)
   case 14:
     wsprintf(buffer, "Ribbon4(%d)", id);
     break;
+  case 16:
+    wsprintf(buffer, "Type A Right Kerb Inside Part(%d)", id);
+    break;
+  case 17:
+    wsprintf(buffer, "Type A Left Kerb Inside Part(%d)", id);
+    break;
   case 19:
     wsprintf(buffer, "Right Bank(%d)", id);
     break;
   case 18:
     wsprintf(buffer, "Left Bank(%d)", id);
     break;
-
+  case 20:
+    wsprintf(buffer, "Pitlane On/Off Ramp(%d)", id);
+    break;
+  case 25:
+    wsprintf(buffer, "Type B Right Kerb Outside Part(%d)", id);
+    break;
+  case 26:
+    wsprintf(buffer, "Type B Left Kerb Outside Part(%d)", id);
+    break;
+  case 27:
+    wsprintf(buffer, "Type B Right Kerb Inside Part(%d)", id);
+    break;
+  case 28:
+    wsprintf(buffer, "Type B Left Kerb Inside Part(%d)", id);
+    break;
   default:
     wsprintf(buffer, "Unk(%d)", id);
     break;

--- a/TrackEditorScrollView.cpp
+++ b/TrackEditorScrollView.cpp
@@ -1555,15 +1555,14 @@ void TrackEditorScrollView::OnImportImage()
 
   int result = fdlg->DoModal();
   if (result == IDOK) {
-    CString file = fdlg->GetFileName();
-    CString dir = fdlg->GetPathName();
+    CString dirfile = fdlg->GetPathName();
     // clear old image
     if (trackImage != NULL) delete trackImage;
 
     trackImage = new CDib();
-    trackImage->Read(file);
+    trackImage->Read(dirfile);
     mytrack->showUnderlayBitmap = TRUE;
-    theApp.WriteProfileString("Preferences", "UnderLayImageName", dir);
+    theApp.WriteProfileString("Preferences", "UnderLayImageName", dirfile);
   }
 }
 


### PR DESCRIPTION
Added location descriptions for kerbs (contrary to what the command library says, they work for 0xbb, 0xbc and 0xc8)  and pit on/off ramps.

Added texture description for the crowd jam.

Also made it store the filename in TrackFileName when opening a file so the save button won't always redirect to save_as.

Fix loading underlay bitmap from menu (when opening a track with the bitmap already loaded it worked fine).